### PR TITLE
set pyext==0.5 to avoid module 'inspect' has no attribute 'getargspec’

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ transformers>=4.25.1
 accelerate>=0.13.2
 datasets>=2.6.1
 evaluate>=0.3.0
-pyext==0.7
+pyext==0.5 # avoid AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'? due to new breaking Python changes
 mosestokenizer==1.0.0
 huggingface_hub>=0.11.1
 fsspec<2023.10.0


### PR DESCRIPTION
AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'? due to new breaking Python changes